### PR TITLE
Upgrade checkout action from v3 to v6

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -11,5 +11,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-        - uses: "actions/checkout@v3"
+        - uses: "actions/checkout@v6"
         - uses: "home-assistant/actions/hassfest@master"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a newer version of the checkout action. This ensures improved security and compatibility with the latest features.

Workflow configuration update:

* [`.github/workflows/hassfest.yml`](diffhunk://#diff-b49043cd95e66c8410326eaf0adf7595f4140d4bb12cebbaf2a9a9d78bd54cf9L14-R14): Updated the `actions/checkout` step from version `v3` to `v6` in the `validate` job.