### PR TITLE
Fix partial-setup notification crash on missing entities

### DIFF
--- a/custom_components/irrigationprogram/__init__.py
+++ b/custom_components/irrigationprogram/__init__.py
@@ -264,6 +264,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.debug(msg)
 
         zone_data = []
+        msg_parts = []
         for zone in config.get(ATTR_ZONES,[]):
             z = IrrigationZoneData(
                 zone=zone.get(ATTR_ZONE),
@@ -289,33 +290,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 adjustment=zone.get(ATTR_WATER_ADJUST),
                 flow_rate=None,
             )
-            msg = None
-            nl = "\n"
             state = hass.states.get(z.zone)
             if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-                msg += f"ERROR {z.zone} has not initialised before the Irrigation Program, this could be a slow registering device, try increasing the 'Wait time from devices that load slowly on startup' setting in the advanced options."
+                msg_parts.append(f"ERROR {z.zone} has not initialised before the Irrigation Program, this could be a slow registering device, try increasing the 'Wait time from devices that load slowly on startup' setting in the advanced options.")
             zone_data.append(z)
             # check if dependant objects are ready
             if z.adjustment:
                 state = hass.states.get(z.adjustment)
                 if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-                    if msg is not None:
-                        msg = f"{nl}"
-                    msg += f"Warning, {z.adjustment} has not initialised before irrigation program, check your configuration{nl}"
+                    msg_parts.append(f"Warning, {z.adjustment} has not initialised before irrigation program, check your configuration")
             if z.rain_sensor:
                 state = hass.states.get(z.rain_sensor)
                 if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-                    if msg is not None:
-                        msg = f"{nl}"
-                    msg += f"Warning, {z.rain_sensor} has not initialised before irrigation program, check your configuration"
-            if msg:
-                async_create(
-                    hass,
-                    message=msg,
-                    title="Irrigation Controller",
-                    notification_id="irrigation_device_error",
-                )
-                continue
+                    msg_parts.append(f"Warning, {z.rain_sensor} has not initialised before irrigation program, check your configuration")
+
+        if msg_parts:
+            async_create(
+                hass,
+                message="\n".join(msg_parts),
+                title="Irrigation Controller",
+                notification_id="irrigation_device_error",
+            )
 
         entry.runtime_data = IrrigationData(program, zone_data)
 

--- a/custom_components/irrigationprogram/tests/test_init.py
+++ b/custom_components/irrigationprogram/tests/test_init.py
@@ -43,9 +43,12 @@ class MockHomeAssistant:
     """Mock HomeAssistant for testing."""
 
     def __init__(self):
-        self.data = {}
+        self.data = {DOMAIN: {}}
         self.config_entries = MagicMock()
+        self.config_entries.async_forward_entry_setups = AsyncMock()
         self.states = MagicMock()
+        self.bus = MagicMock()
+        self.is_running = True
 
     def async_available(self, entity_id):
         """Mock async_available."""
@@ -135,6 +138,91 @@ async def test_async_setup_entry_basic(mock_hass, mock_config_entry):
         assert len(zones) == 1
         assert isinstance(zones[0], IrrigationZoneData)
         assert zones[0].zone == "switch.zone1"
+
+
+@pytest.mark.asyncio
+async def test_deferred_partial_setup_survives_missing_zone_entities(
+    mock_hass, mock_config_entry
+):
+    """Partial setup must complete when zone entities are genuinely missing.
+
+    The missing-entity notification path is the whole point of partial setup;
+    it must raise the notification and still bind the program, not crash.
+    Every missing zone must be reported in a single aggregated notification -
+    a shared notification_id means a per-zone notification would leave only the
+    last zone visible.
+    """
+    zone2 = dict(mock_config_entry.options[ATTR_ZONES][0])
+    zone2[ATTR_ZONE] = "switch.zone2"
+    mock_config_entry.options = {
+        **mock_config_entry.options,
+        ATTR_ZONES: [mock_config_entry.options[ATTR_ZONES][0], zone2],
+    }
+    mock_hass.is_running = False
+    mock_hass.states.get.return_value = None  # nothing has loaded yet
+    captured = {}
+    mock_hass.bus.async_listen_once = MagicMock(
+        side_effect=lambda event, cb: captured.__setitem__("cb", cb)
+    )
+
+    assert await async_setup_entry(mock_hass, mock_config_entry) is True
+
+    with (
+        patch(
+            "custom_components.irrigationprogram.asyncio.wait_for",
+            side_effect=asyncio.TimeoutError,
+        ),
+        patch("custom_components.irrigationprogram.async_create") as notify,
+    ):
+        await captured["cb"](MagicMock())  # must not raise
+
+    assert mock_config_entry.runtime_data is not None
+    mock_hass.config_entries.async_forward_entry_setups.assert_awaited()
+    notify.assert_called_once()
+    message = notify.call_args.kwargs["message"]
+    assert "switch.zone1" in message
+    assert "switch.zone2" in message
+
+
+@pytest.mark.asyncio
+async def test_deferred_partial_setup_survives_missing_zone_sensors(
+    mock_hass, mock_config_entry
+):
+    """Partial setup must warn (not crash) when only zone sensors are missing."""
+    zone = dict(mock_config_entry.options[ATTR_ZONES][0])
+    zone[ATTR_RAIN_SENSOR] = "sensor.rain1"
+    zone[ATTR_WATER_ADJUST] = "sensor.adjust1"
+    mock_config_entry.options = {
+        **mock_config_entry.options,
+        ATTR_ZONES: [zone],
+    }
+    mock_hass.is_running = False
+    zone_state = MagicMock()
+    zone_state.state = "off"
+    mock_hass.states.get.side_effect = (
+        lambda entity_id: zone_state if entity_id == "switch.zone1" else None
+    )
+    captured = {}
+    mock_hass.bus.async_listen_once = MagicMock(
+        side_effect=lambda event, cb: captured.__setitem__("cb", cb)
+    )
+
+    assert await async_setup_entry(mock_hass, mock_config_entry) is True
+
+    with (
+        patch(
+            "custom_components.irrigationprogram.asyncio.wait_for",
+            side_effect=asyncio.TimeoutError,
+        ),
+        patch("custom_components.irrigationprogram.async_create") as notify,
+    ):
+        await captured["cb"](MagicMock())  # must not raise
+
+    assert mock_config_entry.runtime_data is not None
+    notify.assert_called_once()
+    message = notify.call_args.kwargs["message"]
+    assert "sensor.adjust1" in message
+    assert "sensor.rain1" in message
 
 
 async def test_irrigation_program_initialization(mock_config_entry):


### PR DESCRIPTION
Addresses #302.

**What:** In `async_setup_entry`, the missing-entity notification block initialised `msg` to `None` and then appended with `+=`, raising `TypeError` the moment any required entity is absent — which is the only situation this path runs (traceback in #302 at `__init__.py:296`). When setup is deferred until Home Assistant has started, the exception is swallowed by the event bus and the config entry loads empty.

Two further bugs in the same block meant the notification was never usefully shown:
- the accumulator was reset to a bare newline (`msg = f"{nl}"`) instead of appended, discarding earlier warnings;
- `async_create` was called once per zone with a shared `notification_id`, so only the last missing zone's warning survived.

**Why:** Accumulate every warning into a list across all zones and raise a single notification after the zone loop, joining the parts with newlines — this removes the `None` seed and produces one notification listing all missing entities.

**Tests:** Two regression tests reproduce the exact deferred-setup traceback and assert the aggregated notification lists every missing entity — `test_deferred_partial_setup_survives_missing_zone_entities` and `test_deferred_partial_setup_survives_missing_zone_sensors`. The test double is extended with the `bus`, `is_running`, and `async_forward_entry_setups` attributes the deferred path exercises.

Based on V2026.06.01.

Happy for you to merge, adapt, or reimplement — whatever suits your workflow.
