### PR TITLE
Fix valve-domain pump actuation and tolerate lagging pump state

### DIFF
--- a/custom_components/irrigationprogram/pump.py
+++ b/custom_components/irrigationprogram/pump.py
@@ -12,7 +12,15 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .const import CONST_OFF_DELAY, CONST_ON, CONST_OPEN, CONST_SWITCH
+from .const import (
+    CONST_CLOSED,
+    CONST_OFF,
+    CONST_OFF_DELAY,
+    CONST_ON,
+    CONST_OPEN,
+    CONST_SWITCH,
+    CONST_VALVE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,6 +31,9 @@ class PumpClass:
     def __init__(self, hass: HomeAssistant, pump, zones, program=None) -> None:  # noqa: D107
         self.hass = hass
         self._pump = pump
+        # a valve-domain entity uses open/close services; anything else
+        # (switch, input_boolean, …) uses turn_on/turn_off
+        self._valve = str(pump).split(".")[0] == CONST_VALVE
         self._zones = zones
         self._off_delay = CONST_OFF_DELAY
         self._program = program
@@ -73,23 +84,27 @@ class PumpClass:
     async def async_stop(self):
         """Turn off pump."""
         state = self.hass.states.get(self._pump)
-        if state and state.state == "on":
+        if self._valve:
+            # close unless already confirmed closed (tolerates unknown/lagging state)
+            if state and state.state != CONST_CLOSED:
+                await self.hass.services.async_call(
+                    CONST_VALVE, SERVICE_CLOSE_VALVE, {ATTR_ENTITY_ID: self._pump}
+                )
+        elif state and state.state != CONST_OFF:
             await self.hass.services.async_call(
                 CONST_SWITCH, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: self._pump}
-            )
-        if state == "open":
-            await self.hass.services.async_call(
-                "valve", SERVICE_CLOSE_VALVE, {ATTR_ENTITY_ID: self._pump}
             )
 
     async def async_start(self):
         """Turn on the pump."""
         state = self.hass.states.get(self._pump)
-        if state and state.state == "off":
+        if self._valve:
+            # open unless already confirmed open (tolerates unknown/lagging state)
+            if state and state.state != CONST_OPEN:
+                await self.hass.services.async_call(
+                    CONST_VALVE, SERVICE_OPEN_VALVE, {ATTR_ENTITY_ID: self._pump}
+                )
+        elif state and state.state != CONST_ON:
             await self.hass.services.async_call(
                 CONST_SWITCH, SERVICE_TURN_ON, {ATTR_ENTITY_ID: self._pump}
-            )
-        if state == "closed":
-            await self.hass.services.async_call(
-                "valve", SERVICE_OPEN_VALVE, {ATTR_ENTITY_ID: self._pump}
             )

--- a/custom_components/irrigationprogram/tests/test_pump.py
+++ b/custom_components/irrigationprogram/tests/test_pump.py
@@ -1,0 +1,173 @@
+"""Tests for PumpClass valve/switch actuation.
+
+Covers the fix for driving a valve-domain pump (open/close services) and
+tolerating a lagging/``unknown`` state: the pump is commanded unless it is
+already confirmed to be in the target state.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_CLOSE_VALVE,
+    SERVICE_OPEN_VALVE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+
+from custom_components.irrigationprogram.pump import PumpClass
+
+
+def _make_pump(entity_id):
+    """Build a PumpClass with a mock hass, neutralising constructor side effects."""
+    hass = MagicMock()
+    # The constructor schedules async_stop() via async_create_task; close the
+    # coroutine without running it so it neither warns nor pollutes call counts.
+    hass.async_create_task = MagicMock(side_effect=lambda coro: coro.close())
+    hass.bus.async_listen = MagicMock()
+    hass.services.async_call = AsyncMock()
+    pump = PumpClass(hass, entity_id, [], None)
+    hass.services.async_call.reset_mock()
+    return hass, pump
+
+
+def _set_state(hass, value):
+    """Point hass.states.get at a State with .state == value (or None)."""
+    if value is None:
+        hass.states.get.return_value = None
+    else:
+        state = MagicMock()
+        state.state = value
+        hass.states.get.return_value = state
+
+
+# --- valve-domain pump: async_start opens ---------------------------------
+
+@pytest.mark.asyncio
+async def test_valve_pump_opens_when_closed():
+    """A closed valve pump is opened on start (regression: object-vs-string bug)."""
+    hass, pump = _make_pump("valve.pump1")
+    _set_state(hass, "closed")
+    await pump.async_start()
+    hass.services.async_call.assert_awaited_once_with(
+        "valve", SERVICE_OPEN_VALVE, {ATTR_ENTITY_ID: "valve.pump1"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_valve_pump_opens_when_unknown():
+    """A valve reporting 'unknown' is still opened (lagging-state tolerance)."""
+    hass, pump = _make_pump("valve.pump1")
+    _set_state(hass, "unknown")
+    await pump.async_start()
+    hass.services.async_call.assert_awaited_once_with(
+        "valve", SERVICE_OPEN_VALVE, {ATTR_ENTITY_ID: "valve.pump1"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_valve_pump_not_reopened_when_open():
+    """An already-open valve is not commanded again on start."""
+    hass, pump = _make_pump("valve.pump1")
+    _set_state(hass, "open")
+    await pump.async_start()
+    hass.services.async_call.assert_not_awaited()
+
+
+# --- valve-domain pump: async_stop closes ---------------------------------
+
+@pytest.mark.asyncio
+async def test_valve_pump_closes_when_open():
+    """An open valve pump is closed on stop."""
+    hass, pump = _make_pump("valve.pump1")
+    _set_state(hass, "open")
+    await pump.async_stop()
+    hass.services.async_call.assert_awaited_once_with(
+        "valve", SERVICE_CLOSE_VALVE, {ATTR_ENTITY_ID: "valve.pump1"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_valve_pump_closes_when_unknown():
+    """A valve reporting 'unknown' is still closed on stop."""
+    hass, pump = _make_pump("valve.pump1")
+    _set_state(hass, "unknown")
+    await pump.async_stop()
+    hass.services.async_call.assert_awaited_once_with(
+        "valve", SERVICE_CLOSE_VALVE, {ATTR_ENTITY_ID: "valve.pump1"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_valve_pump_not_reclosed_when_closed():
+    """An already-closed valve is not commanded again on stop."""
+    hass, pump = _make_pump("valve.pump1")
+    _set_state(hass, "closed")
+    await pump.async_stop()
+    hass.services.async_call.assert_not_awaited()
+
+
+# --- switch-domain pump: unchanged happy path + unknown tolerance ----------
+
+@pytest.mark.asyncio
+async def test_switch_pump_turns_on_when_off():
+    """A switch pump that is off is turned on."""
+    hass, pump = _make_pump("switch.pump1")
+    _set_state(hass, "off")
+    await pump.async_start()
+    hass.services.async_call.assert_awaited_once_with(
+        "switch", SERVICE_TURN_ON, {ATTR_ENTITY_ID: "switch.pump1"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_switch_pump_turns_on_when_unknown():
+    """A switch reporting 'unknown' is turned on (lagging-state tolerance)."""
+    hass, pump = _make_pump("switch.pump1")
+    _set_state(hass, "unknown")
+    await pump.async_start()
+    hass.services.async_call.assert_awaited_once_with(
+        "switch", SERVICE_TURN_ON, {ATTR_ENTITY_ID: "switch.pump1"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_switch_pump_not_reissued_when_on():
+    """An already-on switch is not commanded again on start."""
+    hass, pump = _make_pump("switch.pump1")
+    _set_state(hass, "on")
+    await pump.async_start()
+    hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_switch_pump_turns_off_when_on():
+    """A switch pump that is on is turned off on stop."""
+    hass, pump = _make_pump("switch.pump1")
+    _set_state(hass, "on")
+    await pump.async_stop()
+    hass.services.async_call.assert_awaited_once_with(
+        "switch", SERVICE_TURN_OFF, {ATTR_ENTITY_ID: "switch.pump1"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_switch_pump_not_turned_off_when_off():
+    """An already-off switch is not commanded again on stop."""
+    hass, pump = _make_pump("switch.pump1")
+    _set_state(hass, "off")
+    await pump.async_stop()
+    hass.services.async_call.assert_not_awaited()
+
+
+# --- missing entity (state is None) → no action (file idiom) ---------------
+
+@pytest.mark.asyncio
+async def test_no_action_when_state_missing():
+    """A pump whose entity has no state is left alone (None-guard)."""
+    hass, pump = _make_pump("valve.pump1")
+    _set_state(hass, None)
+    await pump.async_start()
+    await pump.async_stop()
+    hass.services.async_call.assert_not_awaited()


### PR DESCRIPTION
Addresses #306.

## What

`PumpClass.async_start` / `async_stop` compared the `State` object returned by `hass.states.get()` to `"open"`/`"closed"` instead of `state.state`, so the valve branch was dead code — a valve-domain pump was never opened or closed. This routes the service call by the pump entity's domain and commands the pump unless it is already confirmed in the target state, so `unknown`/lagging states are tolerated instead of dropped.

- `pump.py`: detect a `valve.*` pump once in `__init__` (`self._valve`); in `async_start`/`async_stop`, call `valve.open_valve`/`valve.close_valve` for valve pumps and `switch.turn_on`/`switch.turn_off` otherwise, guarding only against the already-in-target-state case.

## Why

The config flow's `ATTR_PUMP` selector accepts `{"domain": ["switch", "valve"]}`, so valve pumps are a reachable configuration that never actuated. See the linked issue for the root-cause walkthrough with line references.

## Tests

Adds `custom_components/irrigationprogram/tests/test_pump.py` — 12 self-contained tests (MagicMock hass, no HA test harness needed) covering: valve open/close on start/stop, valve `unknown`-state tolerance, valve no-op when already open/closed, switch on/off happy paths, switch `unknown`-state tolerance, switch no-op when already on/off, and the None-state (missing entity) guard.

Based on V2026.06.01 (`bc74bb9`).

Closes the linked issue.
