### PR TITLE
Avoid import-time-frozen default for last_ran in async_turn_on_from_program

### DIFF
--- a/custom_components/irrigationprogram/tests/test_zone_last_ran.py
+++ b/custom_components/irrigationprogram/tests/test_zone_last_ran.py
@@ -1,0 +1,72 @@
+"""Regression test for the last_ran default of Zone.async_turn_on_from_program.
+
+The parameter default must not be a call to ``dt_util.now()``: Python
+evaluates default arguments once, at import time, so a literal timestamp
+default would freeze for every call that omits the argument. The default is
+``None`` and the current local time is computed inside the function body,
+per call.
+
+Self-contained: no running Home Assistant instance is required. The test
+drives the real coroutine against a minimal stand-in object, with ``repeat``
+set to 0 so the watering loop is skipped and execution reaches the block
+that stores ``last_ran``.
+
+Run from the repo root:
+    PYTHONPATH=. python -m pytest \
+        custom_components/irrigationprogram/tests/test_zone_last_ran.py -v
+"""
+
+from datetime import datetime
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.irrigationprogram.zone import Zone
+
+
+class _MinimalZone:
+    """Just enough surface for the reachable path of the coroutine."""
+
+    ignore_sensors = True
+    repeat = 0
+
+    async def status_sensor_set(self, *args, **kwargs):
+        return None
+
+    async def sensor_last_ran_set(self, *args, **kwargs):
+        return None
+
+    async def remaining_time_set(self, *args, **kwargs):
+        return None
+
+    async def async_turn_off_zone_natural(self, *args, **kwargs):
+        return None
+
+    def async_schedule_update_ha_state(self, *args, **kwargs):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_omitted_last_ran_uses_fresh_now():
+    """Omitting last_ran stores the current local time, not a frozen value."""
+    zone = _MinimalZone()
+
+    before = dt_util.as_local(dt_util.now())
+    await Zone.async_turn_on_from_program(zone)
+    after = dt_util.as_local(dt_util.now())
+
+    assert isinstance(zone._last_ran, datetime)
+    # A time computed inside the call falls within the bracket; an
+    # import-time-frozen default would predate `before`.
+    assert before <= zone._last_ran <= after
+
+
+@pytest.mark.asyncio
+async def test_explicit_last_ran_is_preserved():
+    """An explicit last_ran is stored unchanged (guard only fires on None)."""
+    zone = _MinimalZone()
+    supplied = dt_util.as_local(dt_util.now()).replace(year=2000)
+
+    await Zone.async_turn_on_from_program(zone, last_ran=supplied)
+
+    assert zone._last_ran == supplied

--- a/custom_components/irrigationprogram/zone.py
+++ b/custom_components/irrigationprogram/zone.py
@@ -1290,10 +1290,13 @@ class Zone(SwitchEntity, RestoreEntity):
             self._zone_manual_start = True
             await self._programdata.switch.entity_toggle_zone(self._zonedata)
 
-    async def async_turn_on_from_program(self, last=False, last_ran=dt_util.as_local(dt_util.now())):
+    async def async_turn_on_from_program(self, last=False, last_ran=None):
         """Start the zone watering cycle."""
         # last indicates this is the last zone to be run
-        # last_ran is the start time of the program
+        # last_ran is the start time of the program; default to the current
+        # local time when the caller does not supply one
+        if last_ran is None:
+            last_ran = dt_util.as_local(dt_util.now())
         self._state = self._status_sensor = self._status = CONST_ON
         await self.status_sensor_set()
         self.async_schedule_update_ha_state()


### PR DESCRIPTION
Addresses #308.

## What

`Zone.async_turn_on_from_program` declared `last_ran=dt_util.as_local(dt_util.now())`. Default arguments are evaluated once at import, so this froze a single import-time timestamp for every call that omits the argument. This changes the default to `None` and computes `dt_util.as_local(dt_util.now())` inside the function body when no `last_ran` is supplied.

## Why

Defensive correctness / API-contract hygiene. The sole in-tree caller (`program.py:989`) always passes `last_ran` explicitly, so the frozen default is not reachable today and this is not tied to any reported symptom — it removes a latent trap for any future caller that relies on the default. Adjacent to prior `last_ran` work.

## Tests

Adds `custom_components/irrigationprogram/tests/test_zone_last_ran.py`:
- `test_omitted_last_ran_uses_fresh_now` — drives the coroutine with `last_ran` omitted (against a minimal stand-in, `repeat=0` so the watering loop is skipped) and asserts the stored value falls within a fresh `before`/`after` bracket, i.e. the time is read at call time rather than import time.
- `test_explicit_last_ran_is_preserved` — an explicit `last_ran` is stored unchanged (the guard only fires on `None`).

Run:

```
PYTHONPATH=. python -m pytest \
    custom_components/irrigationprogram/tests/test_zone_last_ran.py -v
```

Based on V2026.06.01. Details and root cause in the linked issue.
