### PR TITLE
Fix NameError when sunrise parsing fails in update_next_run

### DIFF
--- a/custom_components/irrigationprogram/program.py
+++ b/custom_components/irrigationprogram/program.py
@@ -422,14 +422,14 @@ class IrrigationProgram(SwitchEntity, RestoreEntity):
                     if sunrise:
                         adjusted_sunrise = dt_util.as_local(sunrise + d)
 
-                    # 5. Extract the time component without seconds/micros
-                    target_time = adjusted_sunrise.replace(
-                        second=0, microsecond=0
-                    ).time()
+                        # 5. Extract the time component without seconds/micros
+                        target_time = adjusted_sunrise.replace(
+                            second=0, microsecond=0
+                        ).time()
 
-                    self.hass.async_create_task(
-                        self._program.start_time.async_set_value(target_time)
-                    )
+                        self.hass.async_create_task(
+                            self._program.start_time.async_set_value(target_time)
+                        )
                 except ValueError:
                     # Handle case where offset state isn't a valid number
                     pass

--- a/custom_components/irrigationprogram/tests/test_update_next_run_sun.py
+++ b/custom_components/irrigationprogram/tests/test_update_next_run_sun.py
@@ -1,0 +1,74 @@
+"""Regression tests for sun-based start time handling in update_next_run.
+
+When the sun sensor state cannot be parsed, dt_util.parse_datetime returns
+None; update_next_run must skip the start-time update instead of raising
+NameError on the unbound adjusted_sunrise local.
+
+These tests are self-contained: they build a bare IrrigationProgram with
+mocked collaborators and do not need a running Home Assistant instance.
+
+Run from the repo root:
+    PYTHONPATH=. python -m pytest \
+        custom_components/irrigationprogram/tests/test_update_next_run_sun.py -v
+"""
+
+from datetime import time
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.irrigationprogram.program import IrrigationProgram
+
+
+def _make_program(sun_rising_state):
+    """Build a minimal IrrigationProgram without running __init__."""
+    prog = object.__new__(IrrigationProgram)
+
+    program = MagicMock()
+    program.sunrise_offset.state = "10"
+    program.sunset_offset = None
+    prog._program = program
+
+    hass = MagicMock()
+    sun_state = MagicMock()
+    sun_state.state = sun_rising_state
+    hass.states.get.return_value = sun_state
+    prog._hass = hass
+    prog.hass = hass
+
+    # Stop update_next_run before the zone/run-time recalculation:
+    # only the sun handling at the top is under test here.
+    prog._paused = True
+    prog._zones = []
+    return prog
+
+
+@pytest.mark.asyncio
+async def test_unparseable_sunrise_does_not_raise():
+    """An unparseable sun sensor state must not crash update_next_run."""
+    prog = _make_program("not-a-datetime")
+
+    # Before the fix this raised NameError: 'adjusted_sunrise' referenced
+    # before assignment.
+    await prog.update_next_run()
+
+    prog.hass.async_create_task.assert_not_called()
+    prog._program.start_time.async_set_value.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_valid_sunrise_schedules_start_time_update():
+    """A valid sun sensor state schedules the start-time update with the
+    offset-adjusted local time (seconds/microseconds stripped)."""
+    dt_util.set_default_time_zone(dt_util.UTC)
+
+    # 05:30 UTC + 10 minute offset -> 05:40 local, seconds truncated.
+    prog = _make_program("2026-06-21T05:30:00+00:00")
+
+    await prog.update_next_run()
+
+    assert prog.hass.async_create_task.call_count == 1
+    prog._program.start_time.async_set_value.assert_called_once_with(
+        time(5, 40)
+    )


### PR DESCRIPTION
Addresses #310.

## What

In `IrrigationProgram.update_next_run`, the sunrise branch computed `target_time` from `adjusted_sunrise` and scheduled the start-time update *outside* the `if sunrise:` guard. When `dt_util.parse_datetime(sensor.sun_next_rising)` returns `None`, `adjusted_sunrise` is never bound and the code raised `NameError` (not caught by the surrounding `except ValueError`), aborting `update_next_run` for sunrise-scheduled programs and leaving next-run/run-duration sensors stale.

This moves the `target_time` computation and the `async_set_value` task inside the existing `if sunrise:` guard, so a failed parse skips the update. This mirrors the sunset branch, which already guards correctly.

## Why

A transient unparseable `sensor.sun_next_rising` state should not crash `update_next_run`. Only the sunrise path was affected; sunset already nests the update under `if sunset:`.

## Tests

Adds `custom_components/irrigationprogram/tests/test_update_next_run_sun.py`:
- `test_unparseable_sunrise_does_not_raise` — an unparseable sun state no longer raises and schedules no start-time update (fails with `NameError` before the fix).
- `test_valid_sunrise_schedules_start_time_update` — a valid state still schedules the update with the offset-adjusted local time, seconds/microseconds stripped.

The tests are self-contained (mocked collaborators, no running Home Assistant):

```
PYTHONPATH=. python -m pytest \
    custom_components/irrigationprogram/tests/test_update_next_run_sun.py -v
```

Based on V2026.06.01 (`bc74bb9`). Fixes the issue linked above.
