### PR TITLE
Guard sensor async_update against unregistered program/zone

### DIFF
--- a/custom_components/irrigationprogram/sensor.py
+++ b/custom_components/irrigationprogram/sensor.py
@@ -105,10 +105,9 @@ class ZoneStatus(SensorEntity):
         #get the value from the program/zone
         zonename = self._pname+'.'+self._zname
         x = ZONES.get(zonename)
-         # Get the property object from the class
-        if x:
-            value = x.status_sensor_value
-        await self.set_value(value)
+        if x is None:
+            return
+        await self.set_value(x.status_sensor_value)
 
     async def set_value(self, status=CONST_OFF):
         """Set the runtime state value."""
@@ -254,10 +253,9 @@ class ZoneRemainingTime(SensorEntity):
         #get the value from the program/zone
         zonename = self._pname+'.'+self._zname
         x = ZONES.get(zonename)
-         # Get the property object from the class
-        if x:
-            value = x.remaining_time_value
-        await self.set_value(value)
+        if x is None:
+            return
+        await self.set_value(x.remaining_time_value)
 
     async def set_value(self, value):
         """Set the remaining time state value."""
@@ -308,10 +306,9 @@ class ZoneDefaultRunTime(SensorEntity):
         #get the value from the program/zone
         zonename = self._pname+'.'+self._zname
         x = ZONES.get(zonename)
-         # Get the property object from the class
-        if x:
-            value = x.default_run_time
-        await self.set_value(value)
+        if x is None:
+            return
+        await self.set_value(x.default_run_time)
 
     async def set_value(self, value):
         """Set the remaining time state value."""
@@ -361,10 +358,9 @@ class RemainingTime(SensorEntity):
         """Triggered on update freq."""
         #get the value from the program/zone
         x = PROGRAMS.get(self._pname)
-         # Get the property object from the class
-        if x:
-            value = x.remaining_time_value
-        await self.set_value(value)
+        if x is None:
+            return
+        await self.set_value(x.remaining_time_value)
 
     async def set_value(self, value):
         """Set the runtime state value."""
@@ -414,10 +410,9 @@ class DefaultRunTime(SensorEntity):
         """Triggered on update freq."""
         #get the value from the program/zone
         x = PROGRAMS.get(self._pname)
-         # Get the property object from the class
-        if x:
-            value = x.default_run_time_value
-        await self.set_value(value)
+        if x is None:
+            return
+        await self.set_value(x.default_run_time_value)
 
     async def set_value(self, value):
         """Set the runtime state value."""

--- a/custom_components/irrigationprogram/tests/test_sensor_update_guard.py
+++ b/custom_components/irrigationprogram/tests/test_sensor_update_guard.py
@@ -1,0 +1,104 @@
+"""Regression tests: sensor async_update before program/zone registration.
+
+During startup or a config-entry reload the sensor platform can poll before
+the owning program/zone has registered itself in the PROGRAMS/ZONES globals.
+Previously each async_update only assigned ``value`` inside ``if x:`` and
+then unconditionally called ``set_value(value)``, raising NameError when the
+lookup missed. These tests pin the guard: a missing object is a clean no-op,
+and a registered object still propagates its property to set_value.
+
+Self-contained: no live Home Assistant instance required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.irrigationprogram.sensor import (
+    DefaultRunTime,
+    RemainingTime,
+    ZoneDefaultRunTime,
+    ZoneRemainingTime,
+    ZoneStatus,
+)
+
+ZONE_CASES = [
+    (ZoneStatus, "status_sensor_value"),
+    (ZoneRemainingTime, "remaining_time_value"),
+    (ZoneDefaultRunTime, "default_run_time"),
+]
+
+PROGRAM_CASES = [
+    (RemainingTime, "remaining_time_value"),
+    (DefaultRunTime, "default_run_time_value"),
+]
+
+
+def _zone_sensor(cls):
+    sensor = cls(MagicMock(), "prog", "zone1", "uid")
+    sensor.set_value = AsyncMock()
+    return sensor
+
+
+def _program_sensor(cls):
+    sensor = cls(MagicMock(), "prog", "uid")
+    sensor.set_value = AsyncMock()
+    return sensor
+
+
+@pytest.mark.parametrize(("cls", "prop"), ZONE_CASES)
+@pytest.mark.asyncio
+async def test_zone_sensor_update_unregistered_zone_is_noop(cls, prop):
+    """async_update must not raise nor write when the zone is unregistered."""
+    sensor = _zone_sensor(cls)
+    with patch.dict(
+        "custom_components.irrigationprogram.sensor.ZONES", {}, clear=True
+    ):
+        await sensor.async_update()  # must not raise NameError
+    sensor.set_value.assert_not_awaited()
+
+
+@pytest.mark.parametrize(("cls", "prop"), ZONE_CASES)
+@pytest.mark.asyncio
+async def test_zone_sensor_update_registered_zone_propagates_value(cls, prop):
+    """async_update passes the zone property straight through to set_value."""
+    sensor = _zone_sensor(cls)
+    zone = MagicMock()
+    setattr(zone, prop, "expected-value")
+    with patch.dict(
+        "custom_components.irrigationprogram.sensor.ZONES",
+        {"prog.zone1": zone},
+        clear=True,
+    ):
+        await sensor.async_update()
+    sensor.set_value.assert_awaited_once_with("expected-value")
+
+
+@pytest.mark.parametrize(("cls", "prop"), PROGRAM_CASES)
+@pytest.mark.asyncio
+async def test_program_sensor_update_unregistered_program_is_noop(cls, prop):
+    """async_update must not raise nor write when the program is unregistered."""
+    sensor = _program_sensor(cls)
+    with patch.dict(
+        "custom_components.irrigationprogram.sensor.PROGRAMS", {}, clear=True
+    ):
+        await sensor.async_update()  # must not raise NameError
+    sensor.set_value.assert_not_awaited()
+
+
+@pytest.mark.parametrize(("cls", "prop"), PROGRAM_CASES)
+@pytest.mark.asyncio
+async def test_program_sensor_update_registered_program_propagates_value(cls, prop):
+    """async_update passes the program property straight through to set_value."""
+    sensor = _program_sensor(cls)
+    program = MagicMock()
+    setattr(program, prop, "expected-value")
+    with patch.dict(
+        "custom_components.irrigationprogram.sensor.PROGRAMS",
+        {"prog": program},
+        clear=True,
+    ):
+        await sensor.async_update()
+    sensor.set_value.assert_awaited_once_with("expected-value")


### PR DESCRIPTION
Addresses #312.

## What

Fixes a `NameError` in five sensor `async_update` methods in `custom_components/irrigationprogram/sensor.py` (`ZoneStatus`, `ZoneRemainingTime`, `ZoneDefaultRunTime`, `RemainingTime`, `DefaultRunTime`). Each looked its backing object up from the `PROGRAMS` / `ZONES` registry and only assigned `value` inside `if x:`, then unconditionally called `set_value(value)` — raising `NameError` on the unbound local when the lookup missed. Each method now returns early when the lookup misses and passes the property straight to `set_value`.

## Why

These entities set `_attr_should_poll = False`, so `async_update` runs only on a forced/manual refresh (integration reload, `async_update_ha_state(force_refresh=True)`). During startup or a config-entry reload that refresh can fire before the program/zone has registered itself, so the lookup returns `None` and the update raises. See the linked issue for the full root cause.

## Tests

Adds `custom_components/irrigationprogram/tests/test_sensor_update_guard.py` — 10 parametrized cases covering, for all five entities, both the unregistered no-op path (must not raise, must not write) and the registered value-propagation path (property passed straight to `set_value`). Self-contained; no live Home Assistant instance required.

Based on V2026.06.01. Closes the linked issue — happy for you to merge, adapt, or reimplement, whatever suits your workflow.
